### PR TITLE
fix the karma.conf.js

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -18,7 +18,7 @@ module.exports = function (config) {
         pattern: 'dist/bundle.js',
         watched: true, served: true, nocache: true, included: false
       },
-      { pattern: 'src/**/*.js', watched: true },
+      { pattern: 'src/**/*.js', watched: true, included: false },
       { pattern: 'tests/**/*.spec.js', watched: true },
       { pattern: 'tests/**/*.test.js', watched: true }
     ],
@@ -42,6 +42,7 @@ module.exports = function (config) {
       'tests/**/*.test.js': [ 'webpack' ]
     },
     reporters: [ 'progress', 'karmaHTML' ],
+    clearContext:false,
     client: {
       karmaHTML: {
         auto: true,

--- a/tests/_karmaconfig.test.js
+++ b/tests/_karmaconfig.test.js
@@ -2,7 +2,7 @@ import 'karma-html'
 import { customMatchers } from 'jasmine-dom-custom-matchers'
 
 describe('karma setup', function() {
-  beforeAll(function() {
+  beforeAll(function(done) {
     jasmine.addMatchers(customMatchers)
 
     karmaHTML.index.onstatechange = function(ready) {


### PR DESCRIPTION
The `src/**/*.js` files in the `karma.conf.js` file should have `included:false` property defined. If set to `true` *(which is default)*, they are automatically included into `<head></head>` section of karma browser context `document` object `<head></head>` section, rather than **iframe** `document` object `<head></head>` section. They do not need to be included into head section, as the `dist/bundle.js` is already included in the `index.html` head section (and it refers to the correct **iframe** `document` object then). The `{ pattern: 'src/**/*.js', watched: true, included: false },` in `karma.conf.js` can be removed or kept to be watched but then with `included:false` property.

The `/tests/_karmaconfig.test.js` should have `done` callback defined in the `beforeAll` function's callback function. Without `done` specified, the tests are executed immediately *(before the html files are loaded)*.